### PR TITLE
Adds new BCRYPTHashingScheme

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Changelog
 
 - Drop Python 2.6 support.
 
+- Add ``BCRYPTHashingScheme``, optionally available if package is
+  installed with the `bcrypt` extra.
+
 
 4.0.0 (2015-09-30)
 ------------------
@@ -19,4 +22,3 @@ Changelog
 ------------------
 
 - Extracted from ``AccessControl 3.0.11``
-

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ setup(
         'test': [
             'pytest',
         ],
+        'bcrypt': [
+            'bcrypt',
+        ],
     },
     include_package_data=True,
     zip_safe=False,

--- a/src/AuthEncoding/AuthEncoding.py
+++ b/src/AuthEncoding/AuthEncoding.py
@@ -170,31 +170,27 @@ except ImportError:
     bcrypt = None
 
 
+class BCRYPTHashingScheme:
+     """A BCRYPT hashing scheme."""
+
+     @staticmethod
+     def _ensure_bytes(pw, encoding='utf-8'):
+         """Ensures the given password `pw` is returned as bytes."""
+         if isinstance(pw, six.text_type):
+             pw = pw.encode(encoding)
+         return pw
+
+     def encrypt(self, pw):
+         return bcrypt.hashpw(self._ensure_bytes(pw), bcrypt.gensalt())
+
+     def validate(self, reference, attempt):
+         try:
+             return bcrypt.checkpw(self._ensure_bytes(attempt), reference)
+         except ValueError:
+             # Usually due to an invalid salt
+             return False
+
 if bcrypt is not None:
-
-    # bcrypt routines require input as bytes.
-
-    def _ensure_bytes(pw, encoding='utf-8'):
-        """Ensures the given password `pw` is returned as bytes.
-        """
-        if isinstance(pw, six.text_type):
-            pw = pw.encode(encoding)
-        return pw
-
-    class BCRYPTHashingScheme:
-         """A BCRYPT hashing scheme."""
-
-         def encrypt(self, pw):
-             return bcrypt.hashpw(_ensure_bytes(pw), bcrypt.gensalt())
-
-         def validate(self, reference, attempt):
-             try:
-                 valid = bcrypt.checkpw(_ensure_bytes(attempt), reference)
-             except ValueError:
-                 # Usually due to an invalid salt
-                 valid = False
-             return valid
-
     registerScheme(u'BCRYPT', BCRYPTHashingScheme())
 
 

--- a/src/AuthEncoding/AuthEncoding.py
+++ b/src/AuthEncoding/AuthEncoding.py
@@ -188,7 +188,12 @@ if bcrypt is not None:
              return bcrypt.hashpw(_ensure_bytes(pw), bcrypt.gensalt())
 
          def validate(self, reference, attempt):
-             return bcrypt.checkpw(_ensure_bytes(attempt), reference)
+             try:
+                 valid = bcrypt.checkpw(_ensure_bytes(attempt), reference)
+             except ValueError:
+                 # Usually due to an invalid salt
+                 valid = False
+             return valid
 
     registerScheme(u'BCRYPT', BCRYPTHashingScheme())
 

--- a/src/AuthEncoding/AuthEncoding.py
+++ b/src/AuthEncoding/AuthEncoding.py
@@ -188,13 +188,7 @@ if bcrypt is not None:
              return bcrypt.hashpw(_ensure_bytes(pw), bcrypt.gensalt())
 
          def validate(self, reference, attempt):
-             try:
-                 hashed = bcrypt.hashpw(_ensure_bytes(attempt), reference)
-             except ValueError:
-                 valid = False
-             else:
-                 valid = hashed == reference
-             return valid
+             return bcrypt.checkpw(_ensure_bytes(attempt), reference)
 
     registerScheme(u'BCRYPT', BCRYPTHashingScheme())
 


### PR DESCRIPTION
@icemac  Following up from [previous discussions](https://github.com/zopefoundation/AccessControl/pull/11#issuecomment-250685627),
this PR adds optional bcrypt support to `AuthEncoding`.

As dicussed, this adds bcrypt hashing support:
- Only available if package is installed with the `bcrypt` extra

Please note the following omissions:
- I've not set a version pin for the `bcrypt` package (I used latest, which at time of writing was `3.1.1`)
- Tests slow down a lot (tests take ~16 seconds on my laptop)
