### PR TITLE
Drop Python 2.6 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
Support for Python 2.6 was dropped in the last release.  I'm sure this classifier was overlooked by accident.